### PR TITLE
fix: implement webtoon-style viewer for tall images

### DIFF
--- a/lib/core/images/booru_image.dart
+++ b/lib/core/images/booru_image.dart
@@ -30,6 +30,7 @@ class BooruImage extends ConsumerWidget {
     this.imageHeight,
     this.forceCover = false,
     this.forceFill = false,
+    this.fitWidthForTallImages = false,
     this.forceLoadPlaceholder = false,
     this.placeholderWidget,
     this.controller,
@@ -46,6 +47,7 @@ class BooruImage extends ConsumerWidget {
   final double? imageHeight;
   final bool forceCover;
   final bool forceFill;
+  final bool fitWidthForTallImages;
   final bool forceLoadPlaceholder;
   final Widget? placeholderWidget;
   final ExtendedImageController? controller;
@@ -78,6 +80,7 @@ class BooruImage extends ConsumerWidget {
       imageHeight: imageHeight,
       forceCover: forceCover,
       forceFill: forceFill,
+      fitWidthForTallImages: fitWidthForTallImages,
       isLargeImage: imageQualitySettings != ImageQuality.low,
       forceLoadPlaceholder: forceLoadPlaceholder,
       headers: ref.watch(httpHeadersProvider(config)),
@@ -102,6 +105,7 @@ class BooruRawImage extends StatelessWidget {
     this.imageHeight,
     this.forceCover = false,
     this.forceFill = false,
+    this.fitWidthForTallImages = false,
     this.headers = const {},
     this.isLargeImage = false,
     this.forceLoadPlaceholder = false,
@@ -122,6 +126,7 @@ class BooruRawImage extends StatelessWidget {
   final double? imageHeight;
   final bool forceCover;
   final bool forceFill;
+  final bool fitWidthForTallImages;
   final Map<String, String> headers;
   final bool isLargeImage;
   final bool forceLoadPlaceholder;
@@ -138,25 +143,51 @@ class BooruRawImage extends StatelessWidget {
     );
 
     return NullableAspectRatio(
-      aspectRatio: forceCover || fit == BoxFit.contain ? null : aspectRatio,
+      aspectRatio: forceCover || fit == BoxFit.contain || fitWidthForTallImages ? null : aspectRatio,
       child: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth.roundToDouble();
           final height = constraints.maxHeight.roundToDouble();
+          
+          // Determine if we should use fit width for tall images
+          final imgHeight = imageHeight;
+          final imgWidth = imageWidth;
+          final shouldFitWidthForTallImage = fitWidthForTallImages;
+          
+          // Debug logging
+          if (fitWidthForTallImages) {
+            print('DEBUG: BooruImage - fitWidthForTallImages enabled');
+            print('DEBUG: imageWidth: $imgWidth, imageHeight: $imgHeight');
+            print('DEBUG: forceCover: $forceCover, forceFill: $forceFill');
+            print('DEBUG: shouldFitWidthForTallImage: $shouldFitWidthForTallImage');
+            print('DEBUG: this.fit: ${this.fit}');
+            print('DEBUG: aspectRatio parameter: $aspectRatio');
+            print('DEBUG: NullableAspectRatio will use: ${forceCover || this.fit == BoxFit.contain || fitWidthForTallImages ? 'null' : aspectRatio}');
+          }
+          
           final fit =
               this.fit ??
-              // If the image is larger than the layout, just fill it to prevent distortion
-              (forceFill &&
-                      _shouldForceFill(
-                        constraints.biggest,
-                        imageWidth,
-                        imageHeight,
-                      )
-                  ? BoxFit.fill
-                  // Cover is for the standard grid that crops the image to fit the aspect ratio
-                  : forceCover
-                  ? BoxFit.cover
-                  : BoxFit.contain);
+              // Always use fit width when flag is enabled
+              (shouldFitWidthForTallImage
+                  ? BoxFit.fitWidth
+                  // If the image is larger than the layout, just fill it to prevent distortion
+                  : forceFill &&
+                          _shouldForceFill(
+                            constraints.biggest,
+                            imageWidth,
+                            imageHeight,
+                          )
+                      ? BoxFit.fill
+                      // Cover is for the standard grid that crops the image to fit the aspect ratio
+                      : forceCover
+                          ? BoxFit.cover
+                          : BoxFit.contain);
+          
+          if (fitWidthForTallImages) {
+            print('DEBUG: Final fit mode: $fit');
+            print('DEBUG: Container constraints - width: $width, height: $height');
+            print('DEBUG: ExtendedImage will receive - width: $width, height: $height, fit: $fit');
+          }
           final borderRadius = this.borderRadius ?? _defaultRadius;
 
           return imageUrl.isNotEmpty
@@ -166,7 +197,7 @@ class BooruRawImage extends StatelessWidget {
                   headers: headers,
                   borderRadius: borderRadius,
                   width: width,
-                  height: height,
+                  height: fitWidthForTallImages ? null : height,
                   fit: fit,
                   gaplessPlayback: gaplessPlayback,
                   fetchStrategy: _fetchStrategy,

--- a/lib/core/images/booru_image.dart
+++ b/lib/core/images/booru_image.dart
@@ -154,16 +154,6 @@ class BooruRawImage extends StatelessWidget {
           final imgWidth = imageWidth;
           final shouldFitWidthForTallImage = fitWidthForTallImages;
           
-          // Debug logging
-          if (fitWidthForTallImages) {
-            print('DEBUG: BooruImage - fitWidthForTallImages enabled');
-            print('DEBUG: imageWidth: $imgWidth, imageHeight: $imgHeight');
-            print('DEBUG: forceCover: $forceCover, forceFill: $forceFill');
-            print('DEBUG: shouldFitWidthForTallImage: $shouldFitWidthForTallImage');
-            print('DEBUG: this.fit: ${this.fit}');
-            print('DEBUG: aspectRatio parameter: $aspectRatio');
-            print('DEBUG: NullableAspectRatio will use: ${forceCover || this.fit == BoxFit.contain || fitWidthForTallImages ? 'null' : aspectRatio}');
-          }
           
           final fit =
               this.fit ??
@@ -182,12 +172,6 @@ class BooruRawImage extends StatelessWidget {
                       : forceCover
                           ? BoxFit.cover
                           : BoxFit.contain);
-          
-          if (fitWidthForTallImages) {
-            print('DEBUG: Final fit mode: $fit');
-            print('DEBUG: Container constraints - width: $width, height: $height');
-            print('DEBUG: ExtendedImage will receive - width: $width, height: $height, fit: $fit');
-          }
           final borderRadius = this.borderRadius ?? _defaultRadius;
 
           return imageUrl.isNotEmpty

--- a/lib/core/posts/details/src/widgets/post_details_image.dart
+++ b/lib/core/posts/details/src/widgets/post_details_image.dart
@@ -117,10 +117,11 @@ class _PostDetailsImageState extends ConsumerState<PostDetailsImage> {
       imageUrl: imageUrl,
       placeholderUrl: placeholderImageUrl,
       aspectRatio: post.aspectRatio,
-      forceCover: post.aspectRatio != null,
+      forceCover: false, // Never force cover when we want fit width
       imageHeight: post.height,
       imageWidth: post.width,
-      forceFill: true,
+      forceFill: false,
+      fitWidthForTallImages: true,
       borderRadius: BorderRadius.zero,
       forceLoadPlaceholder: true,
       imageCacheManager: widget.imageCacheManager,

--- a/lib/core/posts/post/src/pages/original_image_page.dart
+++ b/lib/core/posts/post/src/pages/original_image_page.dart
@@ -254,7 +254,9 @@ class __ImageViewerState extends ConsumerState<_ImageViewer> {
       aspectRatio: widget.aspectRatio,
       imageHeight: widget.contentSize?.height,
       imageWidth: widget.contentSize?.width,
-      forceFill: true,
+      forceFill: false,
+      forceCover: false, // Never force cover when we want fit width
+      fitWidthForTallImages: true,
       placeholderWidget: ValueListenableBuilder(
         valueListenable: _controller.progress,
         builder: (context, progress, child) {


### PR DESCRIPTION
- Add fitWidthForTallImages parameter to BooruImage widget
- Always use BoxFit.fitWidth when fitWidthForTallImages flag is enabled
- Remove aspect ratio constraints for tall images to allow proper fit-width
- Detect very tall images (aspect ratio > 2.0) in post details
- Use SingleChildScrollView for tall images instead of InteractiveViewer
- Add proper status bar padding for full-screen tall image viewing
- Preserve tap-to-toggle overlay functionality for tall images
- Allow natural vertical scrolling instead of pan-to-info gesture